### PR TITLE
Ability to use functions as defaults

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -4,8 +4,9 @@ import { Body } from './types';
 type Constructor<T> = new (...args: any[]) => T;
 
 export function sanitize(value: unknown): string {
-  if (typeof value === 'string') return value;
-  return JSON.stringify(value);
+  const _value = typeof value === 'function' ? value() : value;
+  if (typeof _value === 'string') return _value;
+  return JSON.stringify(_value);
 }
 
 function toRecords(data: URLSearchParams | FormData): Record<string, any> {
@@ -64,6 +65,8 @@ function toJson(
     _data = toRecords(data);
   } else if (Array.isArray(data)) {
     _data = data;
+  } else if (typeof data === 'function') {
+    _data = data();
   } else {
     _data = Object.assign({}, data);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,7 @@ import { METHOD, CONTENT_TYPE } from './consts';
 
 export type Body = BodyInit | null | Record<string, unknown> | unknown[];
 
-export interface ServiceOptions
-  extends Omit<Omit<RequestInit, 'body'>, 'headers'> {
+export interface ServiceOptions extends Omit<RequestInit, 'body' | 'headers'> {
   method?: METHOD;
   contentType?: CONTENT_TYPE | false;
   headers?: Record<string, string | (() => string)>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,10 +2,11 @@ import { METHOD, CONTENT_TYPE } from './consts';
 
 export type Body = BodyInit | null | Record<string, unknown> | unknown[];
 
-export interface ServiceOptions extends Omit<RequestInit, 'body'> {
+export interface ServiceOptions
+  extends Omit<Omit<RequestInit, 'body'>, 'headers'> {
   method?: METHOD;
   contentType?: CONTENT_TYPE | false;
-  headers?: Record<string, string>;
+  headers?: Record<string, string | (() => string)>;
   params?: Record<string, unknown>;
   query?: Record<string, unknown>;
   body?: Body;
@@ -19,7 +20,7 @@ export type ServiceDefinitions = Record<string, ServiceDefinition>;
 
 export type Result = unknown | unknown[];
 
-export type Service = (options: ServiceOptions) => Promise<Result>;
+export type Service = (options?: ServiceOptions) => Promise<Result>;
 
 export interface Services extends Service, Record<string, Services> {}
 

--- a/test/server.ts
+++ b/test/server.ts
@@ -28,6 +28,7 @@ app.post('/body/url', express.urlencoded(), ({ body }, res) =>
 app.post('/body/file', upload.single('file'), ({ file }, res) =>
   res.json({ file: { name: file?.originalname, size: file?.size } })
 );
+app.get('/headers', (req, res) => res.json({ headers: req.headers }));
 
 function build(): Promise<unknown> {
   return new Promise((resolve) => {


### PR DESCRIPTION
Some draft related to [this discussion](https://github.com/aileo/oiler/issues/6) with @JohnBerd.

```js

Authorization() {
  const token = localStorage.getItem('JWT');
  if (!token) return undefined; // do not set header if no token
  return `Bearer ${token}`;
}

const client = new Fetchery('http://foo.bar', { header: { Authorization } })
// then add services and they will get the header filled
```

@JohnBerd can you have a look at the code and tell me what you think about it ?